### PR TITLE
Initaillize Cardsection component

### DIFF
--- a/src/components/UI/CardSection.tsx
+++ b/src/components/UI/CardSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export interface CardSectionProps {
+    title: string;
+    illustration: React.ReactNode; /*아마도 image아니면 svg icon 주입*/
+};
+
+export const CardSection = ({ title, illustration }: CardSectionProps) => {
+    return (
+        <div>
+            <h2>{title}</h2>
+            <div>{illustration}</div>
+        </div>
+    );
+};
+
+export default CardSection;


### PR DESCRIPTION
`CardSection` 컴포넌트를 추가했습니다.
이 컴포넌트는 `title`과 `illustration`을 Props로 받아 렌더링합니다.
`title`은 `h2` 태그로 표시되며, `illustration`은 이미지나 SVG 아이콘과 같은 `React.ReactNode`를 받아 렌더링됩니다.
기본적인 구조만 포함되어 있으며, 스타일링은 추후에 추가될 예정입니다.

title과 illustration을 props로 받아 렌더링
illustration은 img or svg 를 받아 렌더링
스타일링 혹은 추가적인 기능은 회의 후에 추가